### PR TITLE
Leave passwords alone

### DIFF
--- a/identity_smtp.php
+++ b/identity_smtp.php
@@ -49,7 +49,7 @@ class identity_smtp extends rcube_plugin
 
 		$smtp_standard = get_input_value('_smtp_standard', RCUBE_INPUT_POST);
 
-		$password = get_input_value('_smtp_pass', RCUBE_INPUT_POST);
+		$password = get_input_value('_smtp_pass', RCUBE_INPUT_POST, true);
 		
 		if ($password != $identities[$id]['smtp_pass']) {
 			$password = rcmail::get_instance()->encrypt($password);


### PR DESCRIPTION
Secure passwords often contain characters that would be modified by
parse_input_value(), e.g. quotes. Let's just leave the password values
as specified by the user.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>